### PR TITLE
Update fbemail.chunk.tpl

### DIFF
--- a/core/components/formblocks/elements/chunks/fbemail.chunk.tpl
+++ b/core/components/formblocks/elements/chunks/fbemail.chunk.tpl
@@ -2,8 +2,8 @@
 
 [[!fbSimplxWidgeteer?
     &dataSet=`[[!fbEmailGetJSON? &formID=`[[*id]]`]]`
-    &useChunkMatching=`true`
-    &chunkMatchRoot=`true`
+    &useChunkMatching=`1`
+    &chunkMatchRoot=`1`
     &chunkPrefix=`fbEmailRow_`
     &chunkMatchingSelector=`field`
 ]]


### PR DESCRIPTION
  Because snippet properties are interpreted as strings, 'false' evaluates as true. That said, it is common practice to use 0 or 1 representing true or false respectively processing properties in MODx snippets. See http://php.net/manual/en/language.types.boolean.php#language.types.boolean.casting .

Alternatively, one could evaluate the expression, "property === 'false'" during assignment in the snippet.
